### PR TITLE
Debug printer share forbidden error

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,16 @@ python up_print.py --poll
 
 1. Obtains an app-only token using MSAL (`client_credentials`) for the `https://graph.microsoft.com/.default` scope.
 2. Resolves/validates a printer share and creates a print job under `/print/shares/{shareId}/jobs`.
-3. Creates a document (setting `contentType`) and an upload session, then uploads the file in chunks with `Content-Range` headers.
-4. Starts the job and optionally polls `/print/shares/{shareId}/jobs/{jobId}` reading `printJob.status.state` until a terminal state.
+3. Fetches the printer's defaults and includes a job `configuration` to avoid 400 "Missing configuration" from some connectors.
+4. Creates a document (setting `contentType`) and an upload session, then uploads the file in chunks with `Content-Range` headers.
+5. Starts the job and optionally polls `/print/shares/{shareId}/jobs/{jobId}` reading `printJob.status.state` until a terminal state.
 
 ### Notes
 
 - Use files that your printer supports (PDF/XPS preferred). Office formats may require conversion.
 - Ensure the service principal of your app has access to the tenant and Universal Print. Some tenants restrict Universal Print to specific groups.
 - The script prints basic status lines; you can extend error handling and logging as needed.
+
+#### About 400 "Missing configuration"
+
+Some Universal Print connectors require specific job configuration to be present when creating a job. The script now fetches `print/printers/{printerId}?$select=defaults` and maps known defaults (e.g., `copies`, `colorMode`, `duplexMode`, `mediaSize`) into the job creation payload. This eliminates the 400 error in most cases. You can inspect what is sent using `--debug`.


### PR DESCRIPTION
Add job configuration to print job creation to resolve "Missing configuration" (400) errors.

Some Universal Print connectors require specific job configuration to be present when creating a job. This PR fetches printer defaults and maps them into the job creation payload to satisfy this requirement.

---
<a href="https://cursor.com/background-agent?bcId=bc-79b70762-d3d8-494f-a3c4-7873b615aee4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-79b70762-d3d8-494f-a3c4-7873b615aee4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

