### PR TITLE
Debug print job creation failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,6 @@ python up_print.py \
   --printer-id "<printer-guid>" \
   --share-id "<printer-share-guid>" \  # optional; will auto-resolve if omitted
   --file "/absolute/path/to/document.pdf" \
-  --content-type "application/pdf" \
   --job-name "My Graph UP Job" \
   --debug \
   --poll
@@ -72,6 +71,12 @@ python up_print.py --poll
 - Use files that your printer supports (PDF/XPS preferred). Office formats may require conversion.
 - Ensure the service principal of your app has access to the tenant and Universal Print. Some tenants restrict Universal Print to specific groups.
 - The script prints basic status lines; you can extend error handling and logging as needed.
+
+#### Content type detection
+
+- The script now auto-detects the document `contentType` using extension and magic-byte sniffing for common formats (PDF, JPEG, PNG, GIF, TIFF, PS, XPS/OXPS).
+- You can still override detection with `--content-type` (e.g., `--content-type application/pdf`).
+- Use `--debug` to see the resolved `contentType` and its detection source.
 
 #### About 400 "Missing configuration"
 


### PR DESCRIPTION
Add automatic content type detection for print document uploads to simplify usage and prevent 404 errors.

The Universal Print API does not auto-detect document `contentType`, which frequently leads to "Create document failed: 404" errors if not explicitly provided. This change introduces heuristics (extension and magic-byte sniffing) to automatically determine the correct `contentType`, making document uploads more robust.

---
<a href="https://cursor.com/background-agent?bcId=bc-a7fb216b-e829-4977-8d2d-ab97bc57eaa0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a7fb216b-e829-4977-8d2d-ab97bc57eaa0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

